### PR TITLE
Fix group update bug

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -241,7 +241,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       
       // Only allow updating specific fields like name for now
-      const allowedUpdates = { name: req.body.name };
+      const allowedUpdates: Partial<Group> = {};
+      if (typeof req.body.name === 'string') {
+        allowedUpdates.name = req.body.name;
+      }
+
+      if (Object.keys(allowedUpdates).length === 0) {
+        return res.status(400).json({ error: "No valid fields to update" });
+      }
+
       const updatedGroup = await storage.updateGroup(groupId, allowedUpdates);
       
       // Log activity


### PR DESCRIPTION
## Summary
- fix updateGroup helper to ignore undefined fields
- validate fields in group update route

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for group updates, ensuring only valid fields are processed and preventing empty or invalid update requests.
	- Fixed an issue where undefined fields could overwrite existing group data with empty values during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->