### PR TITLE
Switch database connection to Supabase

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,4 @@
 SUPABASE_URL=https://smrsiolztcggakkgtyab.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtcnNpb2x6dGNnZ2Fra2d0eWFiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0ODA2MjEsImV4cCI6MjA2MjA1NjYyMX0.2Cr3iYDNyaXUNtrYRX0OOI4mnG6od5fY7CYcLU-NCSg
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+DATABASE_URL=postgres://<user>:<password>@<host>:5432/postgres
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# FairShare Setup
+
+This project uses Supabase for authentication and PostgreSQL storage. To run the
+application against your own Supabase project:
+
+1. Create a Supabase project and obtain the values for:
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - the connection string for `DATABASE_URL`
+
+2. Edit `.env.local` and set these variables. A sample is provided:
+
+```
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_ANON_KEY=...
+DATABASE_URL=postgres://<user>:<password>@<host>:5432/postgres
+```
+
+3. Push the database schema to Supabase:
+
+```bash
+node db-push.js
+```
+
+4. Start the development server:
+
+```bash
+npm run dev
+```
+
+The app will now connect to Supabase using the credentials defined in
+`DATABASE_URL`.
+

--- a/db-push.js
+++ b/db-push.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { execSync } from 'child_process';
 
 console.log('Pushing database schema...');

--- a/server/db.ts
+++ b/server/db.ts
@@ -4,15 +4,19 @@ import postgres from 'postgres';
 import * as schema from "@shared/schema";
 import { Pool } from 'pg';  // Using standard pg instead of neon-serverless
 
-// Fixed hardcoded Supabase credentials (in production you would use environment variables)
-const supabaseUrl = 'https://smrsiolztcggakkgtyab.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtcnNpb2x6dGNnZ2Fra2d0eWFiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0ODA2MjEsImV4cCI6MjA2MjA1NjYyMX0.2Cr3iYDNyaXUNtrYRX0OOI4mnG6od5fY7CYcLU-NCSg';
+// Supabase credentials are read from the environment so the app can connect to
+// any Supabase project.
+const supabaseUrl = process.env.SUPABASE_URL || 'https://smrsiolztcggakkgtyab.supabase.co';
+const supabaseKey = process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...';
 
 // Create Supabase client
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
-// Use the existing DATABASE_URL with fallback to a fixed connection string
-const connectionString = process.env.DATABASE_URL || 'postgres://postgres.smrsiolztcggakkgtyab:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtcnNpb2x6dGNnZ2Fra2d0eWFiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0ODA2MjEsImV4cCI6MjA2MjA1NjYyMX0.2Cr3iYDNyaXUNtrYRX0OOI4mnG6od5fY7CYcLU-NCSg@aws-0-us-west-1.pooler.supabase.com:5432/postgres';
+// Use the DATABASE_URL environment variable, falling back to a sample Supabase
+// connection string if not provided.
+const connectionString =
+  process.env.DATABASE_URL ||
+  'postgres://postgres:password@aws-0-us-west-1.pooler.supabase.com:5432/postgres';
 
 // Initialize postgres client for Drizzle ORM
 const client = postgres(connectionString, { max: 10 });
@@ -20,7 +24,8 @@ export const db = drizzle(client, { schema });
 
 // Create a regular PostgreSQL pool for session store compatibility
 // using the standard node-postgres library instead of neon-serverless
-export const pool = new Pool({ 
+export const pool = new Pool({
   connectionString,
   ssl: { rejectUnauthorized: false } // Required for Supabase connection
 });
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";


### PR DESCRIPTION
## Summary
- read env vars via dotenv in the server and db push script
- allow configuring Supabase credentials from environment
- document setup for Supabase
- add DATABASE_URL example in `.env.local`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite: not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive README with setup instructions, environment variable configuration, and development steps for the FairShare project.

- **Chores**
  - Updated environment variable handling to use placeholders and templates for sensitive data.
  - Enabled automatic loading of environment variables from a `.env` file in relevant scripts and server files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->